### PR TITLE
Update to dbus-next 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/emersion/mpris-service",
   "dependencies": {
-    "dbus-next": "^0.5.1",
+    "dbus-next": "^0.7.1",
     "deep-equal": "^1.0.1",
     "source-map-support": "^0.5.11"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -200,30 +200,20 @@ Player.prototype.init = function(opts) {
     this._addPlaylistsInterface(this._bus);
   }
 
-  let exportInterfaces = (name) => {
-      for (let k of Object.keys(this.interfaces)) {
-        let iface = this.interfaces[k];
-        name.export(MPRIS_PATH, iface);
-      }
-  };
+  for (let k of Object.keys(this.interfaces)) {
+    let iface = this.interfaces[k];
+    this._bus.export(MPRIS_PATH, iface);
+  }
 
-  let emitError = (err) => {
-    this.emit('error', err);
-  };
-
-  this._bus.requestName(this.serviceName, dbus.DBUS_NAME_FLAG_DO_NOT_QUEUE)
-    .then(exportInterfaces)
-    .catch((err) => {
-      if (err instanceof dbus.NameExistsError) {
-        // if the name exists, try to take a name for the instance per the spec.
-        // https://specifications.freedesktop.org/mpris-spec/latest/#Bus-Name-Policy
+  this._bus.requestName(this.serviceName, dbus.NameFlag.DO_NOT_QUEUE)
+    .then((reply) => {
+      if (reply === dbus.RequestNameReply.EXISTS) {
         this.serviceName = `${this.serviceName}.instance${process.pid}`;
-        this._bus.requestName(this.serviceName)
-          .then(exportInterfaces)
-          .catch(emitError);
-      } else {
-        emitError(err);
+        return this._bus.requestName(this.serviceName);
       }
+    })
+    .catch((err) => {
+      this.emit('error', err);
     });
 };
 


### PR DESCRIPTION
dbus-next 0.7.1 removes the `Name` class and `NameExistsError` and moves
constants to enum classes.